### PR TITLE
chore: Switch custom Docker image to something more popular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
-Repository for my personal website available at https://www.kunalnagar.in
+# 👋 Hi, I'm Kunal.
 
-To develop locally, run `docker-compose up -d` and access the site at http://localhost:4000
+Welcome! This is the repository for my [personal website](https://www.kunalnagar.in). If you'd like to run this locally, please continue reading.
+
+## Requirements
+* Docker
+* Node 14.x
+
+## Getting started
+
+Here are some commands to get started:
+
+### Development
+
+```
+npm start
+```
+
+The site should be available at `http://localhost:4000`
+
+To stop:
+
+```
+npm stop
+```
+
+
+### View container logs
+
+```
+npm run logs
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   jekyll:
-    image: kunalnagar/ruby-node
+    image: timbru31/ruby-node:2.7-slim-14
     ports:
       - 4000:4000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   jekyll:
-    image: timbru31/ruby-node:2.7-slim-14
+    image: timbru31/ruby-node:2.7-14
     ports:
       - 4000:4000
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5200,8 +5200,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
             "tar": "^6.1.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:webpack": "webpack --mode development --watch",
     "logs": "docker-compose logs -f",
     "pretty-quick": "pretty-quick",
-    "start": "docker-compose up -d",
+    "start": "docker-compose up -d --build",
     "stop": "docker-compose down -v"
   },
   "husky": {


### PR DESCRIPTION
Currently, the `docker-compose.yml` uses the `kunalnagar/ruby-node` image to develop locally. I am no longer maintaining it, hence need to switch it to something more popular. 

Here's [an option](https://github.com/timbru31/docker-ruby-node).