### PR TITLE
fix: remove duplicate lighthouse assertion, brittle sleep, and directory nuke

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -5,7 +5,6 @@ module.exports = {
         assertions: {
           'categories:performance': ['warn', { minScore: 0.8 }],
           'categories:accessibility': ['error', { minScore: 0.8 }],
-          'categories:accessibility': ['error', { minScore: 0.8 }],
           'categories:seo': ['error', { minScore: 0.8 }],
           'categories:best-practices': ['error', { minScore: 0.8 }],
         },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:jekyll": "JEKYLL_ENV=production bundle exec jekyll build",
     "scripts:resume:create": "node scripts/resume/create_text_file.js && node scripts/resume/create_pdf_file.js",
     "dev": "bundle exec jekyll clean && npm run dev:jekyll",
-    "dev:jekyll": "sleep 5 && bundle exec jekyll serve --watch --host=0.0.0.0",
+    "dev:jekyll": "bundle exec jekyll serve --watch --host=0.0.0.0",
     "logs": "docker compose logs -f",
     "pretty-quick": "pretty-quick",
     "release": "semantic-release",

--- a/scripts/resume/create_text_file.js
+++ b/scripts/resume/create_text_file.js
@@ -18,8 +18,7 @@ EDUCATION
 
 ${generateEducationText(json.education[0])}
 `
-fs.rmSync(process.cwd() + '/assets/downloads', { recursive: true, force: true })
-fs.mkdirSync(process.cwd() + '/assets/downloads')
+fs.mkdirSync(process.cwd() + '/assets/downloads', { recursive: true })
 fs.writeFileSync(process.cwd() + json.download.txt, str)
 
 function generateSkillsText(skillsJson) {


### PR DESCRIPTION
## Summary

- **`lighthouserc.js`**: Remove duplicate `categories:accessibility` entry — the second one silently overwrote the first, making the config misleading
- **`package.json`**: Remove `sleep 5` from `dev:jekyll` script — the arbitrary delay is brittle (too short on slow machines, wasted time on fast ones); Jekyll needs no pre-delay
- **`scripts/resume/create_text_file.js`**: Replace `rmSync` + `mkdirSync` with `mkdirSync({ recursive: true })` — the old approach wiped the entire `assets/downloads/` directory before the TXT was written, meaning a crash between the two resume scripts left the directory empty; the new approach never destroys existing files

## Test plan

- [ ] `npm run build` completes successfully and `assets/downloads/` contains both `Resume-KunalNagar.pdf` and `Resume-KunalNagar.txt`
- [ ] `npm run dev` starts Jekyll without a 5-second wait
- [ ] Lighthouse CI passes on the 4 audited URLs (no duplicate assertion noise)