### PR TITLE
fix: template and stylesheet polish

### DIFF
--- a/_includes/components/yt.html
+++ b/_includes/components/yt.html
@@ -1,21 +1,3 @@
-<style>
-  .embed-container {
-    position: relative;
-    padding-bottom: 56.25%;
-    height: 0;
-    overflow: hidden;
-    max-width: 100%;
-  }
-  .embed-container iframe,
-  .embed-container object,
-  .embed-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-</style>
 <div class="embed-container">
   <iframe
     src="https://www.youtube.com/embed/{{ include.id }}"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p class="muted">&copy; {{ "now" | date: "%Y" }} Kunal Nagar</p>
+</footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <nav>
   <ul>
-    <li><a href="/">Kunal Nagar</a></li>
-    <li><a href="/foss">Open Source</a></li>
-    <li><a href="/blog">Blog</a></li>
+    <li><a href="/" {% if page.url == "/" %}class="active"{% endif %}>Kunal Nagar</a></li>
+    <li><a href="/foss" {% if page.url == "/foss" or page.url == "/foss/" %}class="active"{% endif %}>Open Source</a></li>
+    <li><a href="/blog" {% if page.url contains "/blog" %}class="active"{% endif %}>Blog</a></li>
   </ul>
 </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{{ site.description }}" />
     <meta
       property="og:image"
-      content="https://kunalnagar.in/assets/img/post.png"
+      content="https://kunalnagar.in{{ page.image | default: '/assets/img/post.png' }}"
     />
     {% if page.title %} {% assign title = page.title | append: ' - ' | append:
     site.title %} {% else %} {% assign title = site.title %} {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@
     <title>{{ page.title }} - {{ site.title }}</title>
     <meta
       property="og:image"
-      content="https://kunalnagar.in/assets/img/post.png"
+      content="https://kunalnagar.in{{ page.image | default: '/assets/img/post.png' }}"
     />
     <meta property="og:title" content="{{ page.title }} - {{ site.title }}" />
     <meta property="og:description" content="{{ page.description }}" />
@@ -38,7 +38,7 @@
           data-reactions-enabled="1"
           data-emit-metadata="0"
           data-input-position="top"
-          data-theme="light"
+          data-theme="preferred_color_scheme"
           data-lang="en"
           data-loading="lazy"
           crossorigin="anonymous"

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -62,6 +62,29 @@ nav {
     gap: 1rem;
     font-weight: 500;
   }
+
+  a.active {
+    font-weight: 700;
+    text-decoration: underline;
+  }
+}
+
+.embed-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+
+  iframe,
+  object,
+  embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 a {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Home
 ---
 
 <div class="page page-home">


### PR DESCRIPTION
## Summary

- **`_includes/footer.html`**: Add copyright year footer (was empty, rendering a blank line)
- **OG image (`_layouts/default.html`, `_layouts/post.html`)**: Use `page.image | default: '/assets/img/post.png'` — posts can now specify a custom social preview image via `image:` frontmatter
- **Giscus (`_layouts/post.html`)**: Change `data-theme="light"` → `data-theme="preferred_color_scheme"` so comments match the user's OS dark/light preference
- **`index.html`**: Add `title: Home` frontmatter so the browser tab title is explicit
- **`_includes/components/yt.html`**: Remove inline `<style>` block — styles moved to `assets/css/main.scss` under `.embed-container`; duplicate styles were injected for every YouTube embed on a page
- **`_includes/header.html`**: Add active-state class driven by `page.url`
- **`assets/css/main.scss`**: Add `nav a.active { font-weight: 700; text-decoration: underline }` and `.embed-container` styles

> Note: `_includes/components/lightbox-img.html` rename was skipped — 9+ blog posts reference it by the current name, and a rename would be pure churn with no functional benefit.

## Test plan

- [ ] Visit `/`, `/foss`, `/blog` and confirm the correct nav link is bold/underlined on each page
- [ ] View a blog post in OS dark mode — confirm Giscus comment box uses dark theme
- [ ] Check OG `og:image` tag in DevTools on homepage and a blog post — should show `/assets/img/post.png` fallback
- [ ] Verify footer renders with current year on all pages
- [ ] Visit a page with a YouTube embed — confirm video still renders correctly at 16:9