### PR TITLE
chore: upgrade github-pages-deploy-action from v3 to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,8 +42,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run release
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: release
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: release


### PR DESCRIPTION
## Summary

Bump `JamesIves/github-pages-deploy-action` from `releases/v3` to `v4`.

**Breaking change in v4**: all input names changed from `UPPERCASE` to `lowercase`. Using the v3 names in v4 silently does nothing — the deploy step would exit green but the `gh-pages` branch would never update.

| v3 | v4 |
|---|---|
| `GITHUB_TOKEN` | `token` |
| `BRANCH` | `branch` |
| `FOLDER` | `folder` |

## Test plan

- [ ] Merge to `master` and confirm the CD workflow's Deploy step pushes to the `gh-pages` branch
- [ ] Confirm the live site at kunalnagar.in reflects the deploy