### PR TITLE
chore(deps): upgrade prettier from 3.2.5 to 3.8.3

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="light">
   <head>
     <meta charset="utf-8" />

--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="light">
   <head>
     <meta charset="utf-8" />

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="light">
   <head>
     <meta charset="utf-8" />

--- a/_sass/_page-blog-post.scss
+++ b/_sass/_page-blog-post.scss
@@ -1,5 +1,4 @@
 .page-blog-single {
-
   h1 {
     margin-bottom: 0;
   }

--- a/_sass/_page-home.scss
+++ b/_sass/_page-home.scss
@@ -1,5 +1,4 @@
 .page-home {
-
   .about-me {
     margin-top: 2rem;
     display: flex;
@@ -9,15 +8,15 @@
       margin-top: 1rem;
       flex-direction: column-reverse;
     }
-  
+
     h1 {
       margin-top: 0;
     }
-  
+
     p {
       font-style: italic;
     }
-  
+
     img {
       width: 10rem;
       margin-left: 2rem;
@@ -29,5 +28,4 @@
       }
     }
   }
-
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,5 +1,9 @@
-$font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-$font-family-monospace: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+$font-family:
+  -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial,
+  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+$font-family-monospace:
+  ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+  monospace;
 $font-size-monospace: 0.9rem;
 
 $color-body: #222222;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -92,7 +92,6 @@ a {
 }
 
 .page {
-
   a {
     color: $color-link;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "husky": "9.1.7",
         "lint-staged": "16.4.0",
         "pdfkit": "0.18.0",
-        "prettier": "3.2.5",
+        "prettier": "3.8.3",
         "pretty-quick": "4.2.2",
         "semantic-release": "24.0.0",
         "sort-package-json": "3.6.1"
@@ -8655,10 +8655,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "pdfkit": "0.18.0",
-    "prettier": "3.2.5",
+    "prettier": "3.8.3",
     "pretty-quick": "4.2.2",
     "semantic-release": "24.0.0",
     "sort-package-json": "3.6.1"

--- a/scripts/resume/create_pdf_file.js
+++ b/scripts/resume/create_pdf_file.js
@@ -1,75 +1,75 @@
-const fs = require('fs')
-const { getResumeJson } = require('./parse_file')
-const PDFDocument = require('pdfkit')
+const fs = require('fs');
+const { getResumeJson } = require('./parse_file');
+const PDFDocument = require('pdfkit');
 
-const json = getResumeJson()
+const json = getResumeJson();
 
 const doc = new PDFDocument({
   margins: {
     top: 40,
     left: 40,
     bottom: 20,
-    right: 40
-  }
-})
+    right: 40,
+  },
+});
 
-const path = process.cwd() + json.download.pdf
+const path = process.cwd() + json.download.pdf;
 
-renderBio()
-doc.moveDown(2)
-renderSkills()
-doc.moveDown(2)
-renderWorkExperience()
-doc.moveDown(2)
-renderEducation()
+renderBio();
+doc.moveDown(2);
+renderSkills();
+doc.moveDown(2);
+renderWorkExperience();
+doc.moveDown(2);
+renderEducation();
 
-doc.end()
-doc.pipe(fs.createWriteStream(path))
+doc.end();
+doc.pipe(fs.createWriteStream(path));
 
 function renderBio() {
-  doc.fontSize(18)
-    .font('Helvetica-Bold')
-    .text(json.bio.name)
-  doc.fontSize(14)
-    .font('Helvetica-Oblique')
-    .text(json.bio.title)
-  doc.font('Helvetica')
-    .text(json.contact.email.privacyText)
-  doc.text('www.kunalnagar.in')
+  doc.fontSize(18).font('Helvetica-Bold').text(json.bio.name);
+  doc.fontSize(14).font('Helvetica-Oblique').text(json.bio.title);
+  doc.font('Helvetica').text(json.contact.email.privacyText);
+  doc.text('www.kunalnagar.in');
 }
 
 function renderSkills() {
-  const skills = json.skills.map(skill => skill.join(', '))
-  doc.font('Helvetica-Bold')
+  const skills = json.skills.map((skill) => skill.join(', '));
+  doc
+    .font('Helvetica-Bold')
     .text('Skills')
     .moveDown()
     .font('Helvetica')
     .list(skills, {
       indent: 20,
-    })
+    });
 }
 
 function renderWorkExperience() {
-  doc.font('Helvetica-Bold')
-    .text('Work Experience')
-    .font('Helvetica')
-  json.experiences.forEach(experience => {
-    doc.moveDown()
+  doc.font('Helvetica-Bold').text('Work Experience').font('Helvetica');
+  json.experiences.forEach((experience) => {
+    doc
+      .moveDown()
       .font('Helvetica-Bold')
-      .text(`${experience.title}, ${experience.position}, ${experience.location}, ${experience.tenure}`)
+      .text(
+        `${experience.title}, ${experience.position}, ${experience.location}, ${experience.tenure}`,
+      )
       .font('Helvetica')
       .list(experience.points, {
-        indent: 20
-      })
-  })
+        indent: 20,
+      });
+  });
 }
 
 function renderEducation() {
-  const education = json.education[0]
-  doc.font('Helvetica-Bold')
+  const education = json.education[0];
+  doc
+    .font('Helvetica-Bold')
     .text('Education')
     .font('Helvetica')
     .moveDown()
-    .text(`${education.degree}, ${education.field}, ${education.institution}, ${education.tenure}`)
-    .text(`CGPA: ${education.cgpa}`)
+    .text(
+      `${education.degree}, ${education.field}, ${education.institution}, ${education.tenure}`,
+    )
+    .text(`CGPA: ${education.cgpa}`);
 }

--- a/scripts/resume/create_text_file.js
+++ b/scripts/resume/create_text_file.js
@@ -1,7 +1,7 @@
-const fs = require('fs')
-const { getResumeJson } = require('./parse_file')
+const fs = require('fs');
+const { getResumeJson } = require('./parse_file');
 
-const json = getResumeJson()
+const json = getResumeJson();
 
 const str = `${json.bio.name}
 ${json.bio.title}
@@ -17,39 +17,41 @@ ${generateExperiencesText(json.experiences, true)}
 EDUCATION
 
 ${generateEducationText(json.education[0])}
-`
-fs.mkdirSync(process.cwd() + '/assets/downloads', { recursive: true })
-fs.writeFileSync(process.cwd() + json.download.txt, str)
+`;
+fs.mkdirSync(process.cwd() + '/assets/downloads', { recursive: true });
+fs.writeFileSync(process.cwd() + json.download.txt, str);
 
 function generateSkillsText(skillsJson) {
-  let text = ''
-  skillsJson.forEach(skillLine => {
+  let text = '';
+  skillsJson.forEach((skillLine) => {
     text += `- ${skillLine.join(', ')}
-`
-  })
-  return text
+`;
+  });
+  return text;
 }
 
 function generateExperiencesText(experiencesJson, ignoreCompanyLinks) {
-  let text = ''
-  experiencesJson.forEach(experience => {
-    const company = ignoreCompanyLinks ? experience.title : `[${experience.title}](${experience.website})`
+  let text = '';
+  experiencesJson.forEach((experience) => {
+    const company = ignoreCompanyLinks
+      ? experience.title
+      : `[${experience.title}](${experience.website})`;
     text += `
 ${company}, ${experience.position}, ${experience.location}, ${experience.tenure}
 
-`
-    experience.points.forEach(point => {
+`;
+    experience.points.forEach((point) => {
       text += `- ${point}
-`
-    })
-  })
-  return text
+`;
+    });
+  });
+  return text;
 }
 
 function generateEducationText(educationJson) {
-  let text = ''
+  let text = '';
   text += `${educationJson.degree}, ${educationJson.field}, ${educationJson.institution}, ${educationJson.tenure}
 CGPA ${educationJson.cgpa}
-`
-  return text
+`;
+  return text;
 }

--- a/scripts/resume/parse_file.js
+++ b/scripts/resume/parse_file.js
@@ -1,10 +1,10 @@
-const fs = require('fs')
+const fs = require('fs');
 
 const getResumeJson = () => {
-  const data = fs.readFileSync(process.cwd() + '/_data/resume.json')
-  return JSON.parse(data)
-}
+  const data = fs.readFileSync(process.cwd() + '/_data/resume.json');
+  return JSON.parse(data);
+};
 
 module.exports = {
-  getResumeJson
-}
+  getResumeJson,
+};


### PR DESCRIPTION
## Summary

Bump `prettier` from 3.2.5 to 3.8.3 and absorb all formatting changes in a single commit by running `npx prettier --write .`.

This PR is isolated so the formatting churn doesn't pollute other diffs. The only functional change is the version bump — all file modifications are whitespace/formatting only.

**Files reformatted (non-trivial):**
- `scripts/resume/create_pdf_file.js` / `create_text_file.js` / `parse_file.js` — quote style and indentation
- `_sass/_variables.scss`, `_page-home.scss`, `_page-blog-post.scss` — trailing newlines / spacing
- `_layouts/default.html`, `post.html`, `minimal.html` — whitespace

## Test plan

- [ ] `npm run build` succeeds
- [ ] Pre-commit hook runs `pretty-quick` and passes without reformatting anything (all files already formatted)