### PR TITLE
fix: remove footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,0 @@
-<footer>
-  <p class="muted">&copy; {{ "now" | date: "%Y" }} Kunal Nagar</p>
-</footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,5 @@
   </head>
   <body>
     <main>{% include header.html %} {{ content }}</main>
-    {% include footer.html %}
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -46,6 +46,5 @@
         ></script>
       </div>
     </main>
-    {% include footer.html %}
   </body>
 </html>


### PR DESCRIPTION
Remove the copyright footer and the include statements from both layouts. Also deletes _includes/footer.html.